### PR TITLE
Add CI workflow for build and task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: go-task/setup-task@v1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh -s -- -b $HOME/.local/bin
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - run: npm install
+      - run: npm run build
+
+  run-task:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: go-task/setup-task@v1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh -s -- -b $HOME/.local/bin
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - run: task


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow
- install go-task, setup Node and Python
- install uv tool and run npm install + build
- run `task` in a second job

## Testing
- `npm install` *(failed: Exit handler never called)*
- `npm run build` *(failed: vite not found)*
- `task` *(failed: npm install ENOTEMPTY)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683b853213dc832f8fec43d3e0b2be35